### PR TITLE
chore: Restore mocha 6s timeout

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/mocharc",
   "require": ["ts-node/register/files"],
-  "ignore": ["test/fixture-projects"]
+  "ignore": ["test/fixture-projects"],
+  "timeout": 6000
 }


### PR DESCRIPTION
It seems that hardhat just casually times out sometimes. So let us restore the 6s timeout.