### PR TITLE
add test for r1cs default path

### DIFF
--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -56,6 +56,11 @@ describe("Hardhat Circom", function () {
       assertPathIncludes(first.wasm, "/hardhat-defaults/circuits/hash.wasm");
     });
 
+    it("Should use default outputBasePath and r1cs name", function () {
+      const first = this.hre.config.circom.circuits[0];
+      assertPathIncludes(first.r1cs, "/hardhat-defaults/circuits/hash.r1cs");
+    });
+
     it("Should use default outputBasePath and zkey name", function () {
       const first = this.hre.config.circom.circuits[0];
       assertPathIncludes(first.zkey, "/hardhat-defaults/circuits/hash.zkey");


### PR DESCRIPTION
I noticed there wasn't a test for the default output of the r1cs file. so I added it here.