### PR TITLE
feat: allow naming and exporting of verification key json

### DIFF
--- a/test/fixture-projects/hardhat-overrides/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-overrides/hardhat.config.ts
@@ -29,6 +29,7 @@ const config: HardhatUserConfig = {
         wasm: "circuit.wasm",
         r1cs: "circuit.r1cs",
         zkey: "circuit.zkey",
+        vkey: "circuit.vkey.json",
       },
     ],
   },

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -60,6 +60,11 @@ describe("Hardhat Circom", function () {
       const first = this.hre.config.circom.circuits[0];
       assertPathIncludes(first.zkey, "/hardhat-defaults/circuits/hash.zkey");
     });
+
+    it("Should use default outputBasePath and vkey name", function () {
+      const first = this.hre.config.circom.circuits[0];
+      assertPathIncludes(first.vkey, "/hardhat-defaults/circuits/hash.vkey.json");
+    });
   });
 
   describe("Test Overrides", function () {
@@ -114,6 +119,11 @@ describe("Hardhat Circom", function () {
     it("Should override outputBasePath and zkey name", function () {
       const third = this.hre.config.circom.circuits[2];
       assertPathEqualsAbsolute(third.zkey, "/client/public/circuit.zkey");
+    });
+
+    it("Should override outputBasePath and vkey name", function () {
+      const third = this.hre.config.circom.circuits[2];
+      assertPathEqualsAbsolute(third.vkey, "/client/public/circuit.vkey.json");
     });
   });
 });


### PR DESCRIPTION
Added naming and exporting of circuit verification key. I found that I needed the verification key json exported in my workflow, and figured others might as well, so I implemented it here.