### PR TITLE
feat!: Implement circom2 compiler

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
-        node-version: [14.x, 16.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [16.x]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        node-version: [14.x]
+        os: [ubuntu-latest]
+        node-version: [16.x]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     name: Create Release
     timeout-minutes: 20
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
@@ -23,7 +23,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     name: Publish to npm registry
     timeout-minutes: 20
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
           registry-url: "https://registry.npmjs.org"
 
       - name: Prepare for publish

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ module.exports = {
       {
         // (required) The name of the circuit
         name: "init",
+        // (optional) The circom version used to compile circuits (1 or 2), defaults to 2
+        version: 2,
         // (optional) Protocol used to build circuits ("groth16" or "plonk"), defaults to "groth16"
         protocol: "groth16",
         // (optional) Input path for circuit file, inferred from `name` if unspecified
@@ -125,6 +127,7 @@ module.exports = {
       },
       {
         name: "play",
+        version: 1,
         protocol: "plonk",
         circuit: "play/circuit.circom",
         input: "play/input.json",

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ import "hardhat-circom";
 This plugin adds the `circom` task to build circuit(s) into `wasm` and `zkey` file and template them to seperate Verifier contracts saved to the Hardhat sources directory (usually `contracts/`).
 
 ```bash
-Usage: hardhat [GLOBAL OPTIONS] circom [--deterministic <BOOLEAN>] [--debug <BOOLEAN>]
+Usage: hardhat [GLOBAL OPTIONS] circom --circuit <STRING> [--debug] [--deterministic]
 
 OPTIONS:
 
-  --debug               output intermediate files to artifacts directory, generally for debug
-  --deterministic       enable deterministic builds (except for .wasm)
+  --circuit      	limit your circom task to a single circuit name
+  --debug        	output intermediate files to artifacts directory, generally for debug
+  --deterministic	enable deterministic builds for groth16 protocol circuits (except for .wasm)
 
 circom: compile circom circuits and template Verifier
 

--- a/README.md
+++ b/README.md
@@ -252,15 +252,3 @@ async function circuitsCompile(args, hre, runSuper) {
   await runSuper();
 }
 ```
-
-## Circomlib
-
-When working with `circom` (before "circom 2") and `circomlib`, you might need to add a `circom` resolution to your `package.json` because `circomlib` v0.5.5 pins `circom` to v0.5.33, but we need v0.5.46 for this plugin.
-
-Make sure you are using `yarn` and add the following to your `package.json`:
-
-```diff
-+  "resolutions": {
-+    "circom": "0.5.46"
-+  },
-```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "projectsophon/hardhat-circom",
   "license": "GPL-3.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -28,14 +28,11 @@
     "@phated/unionfs": "^4.5.0",
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
-    "circom2": "0.1.0",
+    "circom2": "^0.2.0",
     "debug": "^4.3.3",
     "memfs": "^3.4.1",
     "shimmer": "^1.2.1",
     "snarkjs": "^0.4.14"
-  },
-  "resolutions": {
-    "circom2": "link:../../circom/npm"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
     "watch": "tsc -w"
   },
   "dependencies": {
+    "@phated/unionfs": "^4.5.0",
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
     "circom2": "0.1.0",
     "debug": "^4.3.3",
+    "memfs": "^3.4.1",
     "snarkjs": "^0.4.14"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "circom2": "0.1.0",
     "debug": "^4.3.3",
     "memfs": "^3.4.1",
+    "shimmer": "^1.2.1",
     "snarkjs": "^0.4.14"
   },
   "resolutions": {
@@ -47,6 +48,7 @@
     "@types/debug": "^4.1.7",
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.22",
+    "@types/shimmer": "^1.0.2",
     "chai": "^4.3.6",
     "eslint": "^7.25.0",
     "hardhat": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,12 @@
   "dependencies": {
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
+    "circom2": "0.1.0",
     "debug": "^4.3.3",
     "snarkjs": "^0.4.14"
+  },
+  "resolutions": {
+    "circom2": "link:../../circom/npm"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
 
     config.circom.circuits.push({
       name: name,
-      version: version !== 2 ? 1 : 2,
+      version: version !== 1 ? 2 : 1,
       protocol: protocol !== "plonk" ? "groth16" : "plonk",
       beacon: beacon != null ? beacon : "0000000000000000000000000000000000000000000000000000000000000000",
       circuit: circuitPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as crypto from "crypto";
 import * as fs from "fs/promises";
+import * as nodefs from "fs";
 import { existsSync } from "fs";
 import { extendConfig, extendEnvironment, task, subtask, types } from "hardhat/config";
 import { HardhatPluginError } from "hardhat/plugins";
@@ -9,7 +10,11 @@ import type { HardhatConfig, HardhatRuntimeEnvironment, HardhatUserConfig } from
 
 import snarkjs from "./snarkjs";
 // @ts-ignore because they don't ship types
-import * as circomCompiler from "circom";
+import * as circom1Compiler from "circom";
+// @ts-ignore because they don't ship types
+import CircomRunner from "circom2";
+// @ts-ignore because they don't ship types
+import bindings from "circom2/bindings";
 
 declare module "hardhat/types/runtime" {
   interface HardhatRuntimeEnvironment {
@@ -22,7 +27,7 @@ declare module "hardhat/types/runtime" {
 }
 
 extendEnvironment((hre) => {
-  hre.circom = circomCompiler;
+  hre.circom = circom1Compiler;
   hre.snarkjs = snarkjs;
 });
 
@@ -39,6 +44,7 @@ declare module "hardhat/types/config" {
 
 export interface CircomCircuitUserConfig {
   name?: string;
+  version?: 1 | 2;
   protocol?: "groth16" | "plonk";
   circuit?: string;
   input?: string;
@@ -51,6 +57,7 @@ export interface CircomCircuitUserConfig {
 
 export interface CircomCircuitConfig {
   name: string;
+  version: 1 | 2;
   protocol: "groth16" | "plonk";
   circuit: string;
   input: string;
@@ -123,7 +130,7 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
     circuits: [],
   };
 
-  for (const { name, protocol, beacon, circuit, input, wasm, r1cs, zkey, vkey } of circuits) {
+  for (const { name, version, protocol, beacon, circuit, input, wasm, r1cs, zkey, vkey } of circuits) {
     if (!name) {
       throw new HardhatPluginError(
         PLUGIN_NAME,
@@ -140,7 +147,8 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
 
     config.circom.circuits.push({
       name: name,
-      protocol: protocol ?? "groth16",
+      version: version !== 2 ? 1 : 2,
+      protocol: protocol !== "plonk" ? "groth16" : "plonk",
       beacon: beacon != null ? beacon : "0000000000000000000000000000000000000000000000000000000000000000",
       circuit: circuitPath,
       input: inputPath,
@@ -159,6 +167,105 @@ async function getInputJson(input: string) {
   } catch (err) {
     throw new HardhatPluginError(PLUGIN_NAME, `Failed to parse JSON in file: ${input}`, err as Error);
   }
+}
+
+async function circom1({ circuit, debug }: { circuit: CircomCircuitConfig; debug?: { path: string } }) {
+  const r1csFastFile: MemFastFile = { type: "mem" };
+  const wasmFastFile: MemFastFile = { type: "mem" };
+  const watFastFile: MemFastFile = { type: "mem" };
+  await circom1Compiler.compiler(circuit.circuit, {
+    watFileName: watFastFile,
+    wasmFileName: wasmFastFile,
+    r1csFileName: r1csFastFile,
+  });
+
+  if (!r1csFastFile.data) {
+    throw new HardhatPluginError(PLUGIN_NAME, `Unable to generate r1cs for circuit named: ${circuit.name}`);
+  }
+  if (!wasmFastFile.data) {
+    throw new HardhatPluginError(PLUGIN_NAME, `Unable to generate wasm for circuit named: ${circuit.name}`);
+  }
+
+  if (debug) {
+    await fs.writeFile(path.join(debug.path, `${circuit.name}.r1cs`), r1csFastFile.data);
+    await fs.writeFile(path.join(debug.path, `${circuit.name}.wasm`), wasmFastFile.data);
+
+    // The .wat file is only used for debug
+    if (watFastFile.data) {
+      await fs.writeFile(path.join(debug.path, `${circuit.name}.wat`), watFastFile.data);
+    }
+  }
+
+  return {
+    // the `.data` property is checked above
+    r1cs: r1csFastFile as Required<MemFastFile>,
+    wasm: wasmFastFile as Required<MemFastFile>,
+  } as const;
+}
+
+async function circom2({ circuit, debug }: { circuit: CircomCircuitConfig; debug?: { path: string } }) {
+  // Using unshift here to prefer writing virtual files from the circom2 wasm
+  bindings.fs.fss.unshift(nodefs);
+
+  const r1csDir = path.dirname(circuit.r1cs);
+  // We build virtual paths here because circom2 outputs these into dumb places
+  const wasmDir = path.join(path.dirname(circuit.wasm), `${circuit.name}_js`);
+  const wasmVirtualPath = path.join(wasmDir, `${circuit.name}.wasm`);
+  const watVirtualPath = path.join(wasmDir, `${circuit.name}.wat`);
+
+  // Make the r1cs directory so it doesn't defer to nodefs for writing
+  // but don't make the wasm directory because otherwise circom2 won't proceed
+  await bindings.fs.promises.mkdir(r1csDir, { recursive: true });
+
+  const circom = new CircomRunner({
+    args: [circuit.circuit, "--r1cs", "--wat", "--wasm", "-o", r1csDir],
+    env: {},
+    // Preopen from the root because we use absolute paths
+    preopens: {
+      "/": "/",
+    },
+    bindings,
+  });
+
+  const circomWasm = await fs.readFile(require.resolve("circom2/circom.wasm"));
+
+  await circom.execute(circomWasm);
+
+  const r1csFastFile: MemFastFile = {
+    type: "mem",
+    data: await bindings.fs.promises.readFile(circuit.r1cs),
+  };
+  const wasmFastFile: MemFastFile = {
+    type: "mem",
+    data: await bindings.fs.promises.readFile(wasmVirtualPath),
+  };
+  const watFastFile: MemFastFile = {
+    type: "mem",
+    data: await bindings.fs.promises.readFile(watVirtualPath),
+  };
+
+  if (!r1csFastFile.data) {
+    throw new HardhatPluginError(PLUGIN_NAME, `Unable to generate r1cs for circuit named: ${circuit.name}`);
+  }
+  if (!wasmFastFile.data) {
+    throw new HardhatPluginError(PLUGIN_NAME, `Unable to generate wasm for circuit named: ${circuit.name}`);
+  }
+
+  if (debug) {
+    await fs.writeFile(path.join(debug.path, `${circuit.name}.r1cs`), r1csFastFile.data);
+    await fs.writeFile(path.join(debug.path, `${circuit.name}.wasm`), wasmFastFile.data);
+
+    // The .wat file is only used for debug
+    if (watFastFile.data) {
+      await fs.writeFile(path.join(debug.path, `${circuit.name}.wat`), watFastFile.data);
+    }
+  }
+
+  return {
+    // the `.data` property is checked above
+    r1cs: r1csFastFile as Required<MemFastFile>,
+    wasm: wasmFastFile as Required<MemFastFile>,
+  } as const;
 }
 
 async function groth16({
@@ -339,42 +446,33 @@ async function circomCompile(
       continue;
     }
 
-    const r1csFastFile: MemFastFile = { type: "mem" };
-    const wasmFastFile: MemFastFile = { type: "mem" };
-    const watFastFile: MemFastFile = { type: "mem" };
-    await circomCompiler.compiler(circuit.circuit, {
-      watFileName: watFastFile,
-      wasmFileName: wasmFastFile,
-      r1csFileName: r1csFastFile,
-    });
-
-    if (!r1csFastFile.data) {
-      throw new HardhatPluginError(PLUGIN_NAME, `Unable to generate r1cs for circuit named: ${circuit.name}`);
-    }
-    if (!wasmFastFile.data) {
-      throw new HardhatPluginError(PLUGIN_NAME, `Unable to generate wasm for circuit named: ${circuit.name}`);
-    }
-
-    if (debug) {
-      await fs.writeFile(path.join(debugPath, `${circuit.name}.r1cs`), r1csFastFile.data);
-      await fs.writeFile(path.join(debugPath, `${circuit.name}.wasm`), wasmFastFile.data);
-
-      // The .wat file is only used for debug
-      if (watFastFile.data) {
-        await fs.writeFile(path.join(debugPath, `${circuit.name}.wat`), watFastFile.data);
-      }
+    let r1cs;
+    let wasm;
+    if (circuit.version === 1) {
+      const output = await circom1({
+        circuit,
+        debug: debug ? { path: debugPath } : undefined,
+      });
+      r1cs = output.r1cs;
+      wasm = output.wasm;
+    } else {
+      const output = await circom2({
+        circuit,
+        debug: debug ? { path: debugPath } : undefined,
+      });
+      r1cs = output.r1cs;
+      wasm = output.wasm;
     }
 
-    const _cir = await snarkjs.r1cs.info(r1csFastFile);
+    const _cir = await snarkjs.r1cs.info(r1cs);
 
     if (circuit.protocol === "groth16") {
       const zkey = await groth16({
         circuit,
         deterministic,
         debug: debug ? { path: debugPath } : undefined,
-        // the `.data` property is checked above
-        wasm: wasmFastFile as Required<MemFastFile>,
-        r1cs: r1csFastFile as Required<MemFastFile>,
+        wasm,
+        r1cs,
         ptau,
       });
       zkeys.push(zkey);
@@ -382,9 +480,8 @@ async function circomCompile(
       const zkey = await plonk({
         circuit,
         debug: debug ? { path: debugPath } : undefined,
-        // the `.data` property is checked above
-        wasm: wasmFastFile as Required<MemFastFile>,
-        r1cs: r1csFastFile as Required<MemFastFile>,
+        wasm,
+        r1cs,
         ptau,
       });
       zkeys.push(zkey);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,11 @@
+import debug, { Debugger } from "debug";
+
+const pluginLogger: { [key: string]: Debugger } = {};
+
+type Level = "debug" | "info" | "warn" | "error";
+for (const level of ["debug", "info", "warn", "error"] as Level[]) {
+  pluginLogger[level] = debug(`hardhat-circom:${level}`);
+  pluginLogger[level].log = console[level].bind(console);
+}
+
+export default pluginLogger;

--- a/src/snarkjs.ts
+++ b/src/snarkjs.ts
@@ -1,14 +1,7 @@
-import debug, { Debugger } from "debug";
 // @ts-ignore because they don't ship types
 import * as snarkjs from "snarkjs";
 
-const pluginLogger: { [key: string]: Debugger } = {};
-
-type Level = "debug" | "info" | "warn" | "error";
-for (const level of ["debug", "info", "warn", "error"] as Level[]) {
-  pluginLogger[level] = debug(`hardhat-circom:${level}`);
-  pluginLogger[level].log = console[level].bind(console);
-}
+import pluginLogger from "./logger";
 
 // This is extremely fragile and could break with SnarkJS updates
 // TODO: Get the logger stuff upstreamed?

--- a/test/fixture-projects/hardhat-overrides/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-overrides/hardhat.config.ts
@@ -25,6 +25,7 @@ const config: HardhatUserConfig = {
       },
       {
         name: "init",
+        version: 2,
         circuit: "circuit.circom",
         input: "input.json",
         wasm: "circuit.wasm",

--- a/test/fixture-projects/hardhat-overrides/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-overrides/hardhat.config.ts
@@ -25,7 +25,7 @@ const config: HardhatUserConfig = {
       },
       {
         name: "init",
-        version: 2,
+        version: 1,
         circuit: "circuit.circom",
         input: "input.json",
         wasm: "circuit.wasm",

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -106,6 +106,11 @@ describe("Hardhat Circom", function () {
       assertPathEqualsAbsolute(third.circuit, "/circuits/circuit.circom");
     });
 
+    it("Should override version", function () {
+      const third = this.hre.config.circom.circuits[2];
+      assert.equal(third.version, 2);
+    });
+
     it("Should override inputBasePath and input name", function () {
       const third = this.hre.config.circom.circuits[2];
       assertPathEqualsAbsolute(third.input, "/circuits/input.json");

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -36,6 +36,16 @@ describe("Hardhat Circom", function () {
       assert.equal(first.beacon, "0000000000000000000000000000000000000000000000000000000000000000");
     });
 
+    it("defaults to groth16", function () {
+      const first = this.hre.config.circom.circuits[0];
+      assert.equal(first.protocol, "groth16");
+    });
+
+    it("defaults to circom version 2", function () {
+      const first = this.hre.config.circom.circuits[0];
+      assert.equal(first.version, 2);
+    });
+
     it("Should use default inputBasePath and circuit name", function () {
       const first = this.hre.config.circom.circuits[0];
       assertPathIncludes(first.circuit, "/hardhat-defaults/circuits/hash.circom");
@@ -108,7 +118,7 @@ describe("Hardhat Circom", function () {
 
     it("Should override version", function () {
       const third = this.hre.config.circom.circuits[2];
-      assert.equal(third.version, 2);
+      assert.equal(third.version, 1);
     });
 
     it("Should override inputBasePath and input name", function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,13 +1063,14 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circom2@0.1.0:
-  version "0.0.0"
-  uid ""
-
-"circom2@link:../../circom/npm":
-  version "0.0.0"
-  uid ""
+circom2@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/circom2/-/circom2-0.2.0.tgz#e4a254725d5b02fc084f556639e6fed72c443a40"
+  integrity sha512-ODA9cNWS3+JYZ5QmkX6OZolBj3i1Ra4Ga6FR5fNkUAmG0HdN4v4LIeFPBXQp156cF20rWEFCLoysAzZAJL5gLA==
+  dependencies:
+    "@wasmer/wasi" "^0.12.0"
+    is-typed-array "^1.1.8"
+    path-browserify "^1.0.1"
 
 circom@0.5.46:
   version "0.5.46"

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,6 +608,16 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@wasmer/wasi@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@wasmer/wasi/-/wasi-0.12.0.tgz#89c7c5e5ba58f7dfae4e323359346639c4ec382a"
+  integrity sha512-FJhLZKAfLWm/yjQI7eCRHNbA8ezmb7LSpUYFkHruZXs2mXk2+DaQtSElEtOoNrVQ4vApTyVaAd5/b7uEu8w6wQ==
+  dependencies:
+    browser-process-hrtime "^1.0.0"
+    buffer-es6 "^4.9.3"
+    path-browserify "^1.0.0"
+    randomfill "^1.0.4"
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -787,6 +797,11 @@ async@^2.4.0:
   dependencies:
     lodash "^4.17.14"
 
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
 b4a@^1.0.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.3.1.tgz#5ead1402bd4a2dcfea35cc83928815d53315ff32"
@@ -862,6 +877,11 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
+browser-process-hrtime@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
+  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
+
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -895,6 +915,11 @@ bs58check@^2.1.2:
     create-hash "^1.1.0"
     safe-buffer "^5.1.2"
 
+buffer-es6@^4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/buffer-es6/-/buffer-es6-4.9.3.tgz#f26347b82df76fd37e18bcb5288c4970cfd5c404"
+  integrity sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ=
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -925,7 +950,7 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-call-bind@^1.0.0:
+call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
@@ -1025,6 +1050,14 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+circom2@0.1.0:
+  version "0.0.0"
+  uid ""
+
+"circom2@link:../../circom/npm":
+  version "0.0.0"
+  uid ""
 
 circom@0.5.46:
   version "0.5.46"
@@ -1220,6 +1253,13 @@ deferred-leveldown@~5.3.0:
     abstract-leveldown "~6.2.1"
     inherits "^2.0.3"
 
+define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -1312,6 +1352,41 @@ errno@~0.1.1:
   integrity sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==
   dependencies:
     prr "~1.0.1"
+
+es-abstract@^1.18.5:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
+  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.1"
+    is-string "^1.0.7"
+    is-weakref "^1.0.1"
+    object-inspect "^1.11.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -1724,6 +1799,11 @@ follow-redirects@^1.12.1:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+
 fp-ts@1.19.3:
   version "1.19.3"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.3.tgz#261a60d1088fbff01f91256f91d21d0caaaaa96f"
@@ -1753,6 +1833,11 @@ fs-extra@^7.0.1:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-monkey@1.0.3, fs-monkey@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
+  integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1784,7 +1869,7 @@ get-func-name@^2.0.0:
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
-get-intrinsic@^1.0.2:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -1792,6 +1877,14 @@ get-intrinsic@^1.0.2:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
@@ -1907,6 +2000,11 @@ hardhat@^2.9.1:
     uuid "^8.3.2"
     ws "^7.4.6"
 
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -1917,10 +2015,17 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.1:
+has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has@^1.0.3:
   version "1.0.3"
@@ -2047,12 +2152,28 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 io-ts@1.10.4:
   version "1.10.4"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.10.4.tgz#cd5401b138de88e4f920adbcb7026e2d1967e6e2"
   integrity sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==
   dependencies:
     fp-ts "^1.0.0"
+
+is-bigint@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
+  integrity sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==
+  dependencies:
+    has-bigints "^1.0.1"
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -2061,12 +2182,32 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-boolean-object@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
+  integrity sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-callable@^1.1.4, is-callable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+
 is-core-module@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
+
+is-date-object@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
+  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -2095,6 +2236,18 @@ is-hex-prefixed@1.0.0:
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
   integrity sha1-fY035q135dEnFIkTxXPggtd39VQ=
 
+is-negative-zero@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
+is-number-object@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0"
+  integrity sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -2105,10 +2258,55 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-shared-array-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
+  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+
+is-string@^1.0.5, is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
+is-symbol@^1.0.2, is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
+  dependencies:
+    has-symbols "^1.0.2"
+
+is-typed-array@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.8.tgz#cbaa6585dc7db43318bc5b89523ea384a6f65e79"
+  integrity sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.18.5"
+    foreach "^2.0.5"
+    has-tostringtag "^1.0.0"
+
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-weakref@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2400,6 +2598,13 @@ memdown@^5.0.0:
     ltgt "~2.2.0"
     safe-buffer "~5.2.0"
 
+memfs@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.1.tgz#b78092f466a0dce054d63d39275b24c71d3f1305"
+  integrity sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==
+  dependencies:
+    fs-monkey "1.0.3"
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
@@ -2580,10 +2785,25 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-object-inspect@^1.9.0:
+object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
+object-keys@^1.0.12, object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 obliterator@^2.0.0:
   version "2.0.2"
@@ -2679,6 +2899,11 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+path-browserify@^1.0.0, path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -2806,11 +3031,19 @@ r1csfile@0.0.35:
     fastfile "0.0.19"
     ffjavascript "0.2.48"
 
-randombytes@^2.1.0:
+randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
+    safe-buffer "^5.1.0"
+
+randomfill@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
+  integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
+  dependencies:
+    randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
 raw-body@^2.4.1:
@@ -3139,6 +3372,22 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -3322,10 +3571,27 @@ typescript@4.2.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
+unbox-primitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
 undici@^4.14.1:
   version "4.15.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-4.15.1.tgz#c2c0e75f232178f0e6781f6b46c81ccc15065f6e"
   integrity sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==
+
+unionfs@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/unionfs/-/unionfs-4.4.0.tgz#b671112e505f70678052345cf5c2a33f0e6edde9"
+  integrity sha512-N+TuJHJ3PjmzIRCE1d2N3VN4qg/P78eh/nxzwHnzpg3W2Mvf8Wvi7J1mvv6eNkb8neUeSdFSQsKna0eXVyF4+w==
+  dependencies:
+    fs-monkey "^1.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -3401,6 +3667,17 @@ web-worker@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.2.0.tgz#5d85a04a7fbc1e7db58f66595d7a3ac7c9c180da"
   integrity sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==
+
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,6 +342,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@phated/unionfs@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@phated/unionfs/-/unionfs-4.5.0.tgz#81bd1fc4c6691e30afbe6a6d9b3a0d4ffaaf671a"
+  integrity sha512-n9qDJAbQS3nSkXrzYdNpxtQcPZIju+kHjpU2DLsa9OZ87GpwpUrsbpCWhJpkJInRWDT2a+kFnpNfPmgonPZUvg==
+  dependencies:
+    fs-monkey "^1.0.0"
+
 "@projectsophon/eslint-config@0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@projectsophon/eslint-config/-/eslint-config-0.0.2.tgz#6b96a87f222894aa0eb4491a38d5b9f62bfd5f7f"
@@ -3585,13 +3592,6 @@ undici@^4.14.1:
   version "4.15.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-4.15.1.tgz#c2c0e75f232178f0e6781f6b46c81ccc15065f6e"
   integrity sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==
-
-unionfs@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/unionfs/-/unionfs-4.4.0.tgz#b671112e505f70678052345cf5c2a33f0e6edde9"
-  integrity sha512-N+TuJHJ3PjmzIRCE1d2N3VN4qg/P78eh/nxzwHnzpg3W2Mvf8Wvi7J1mvv6eNkb8neUeSdFSQsKna0eXVyF4+w==
-  dependencies:
-    fs-monkey "^1.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,6 +540,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/shimmer@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.0.2.tgz#93eb2c243c351f3f17d5c580c7467ae5d686b65f"
+  integrity sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg==
+
 "@typescript-eslint/eslint-plugin@^4.22.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
@@ -3272,6 +3277,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shimmer@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Closes #37 

This is a WIP of implementing the circom2 compiler (in wasm) with hardhat-circom.

This will be "opt-in" during the 2.x release cycle by specifying `version: 2` on your circuit config, but it will be made the default in the 3.0 release.

Additionally, `hre.circom` is going to be removed in 3.0 because we are supporting multiple compilers and it is really difficult to setup/configure the circom2 compiler. If people actually use this, please let me know.

I've tested this in [snarky-sudoku](https://github.com/nalinbhardwaj/snarky-sudoku/tree/circom2-merged) and everything seems to be working. 