### PR TITLE
fix: Print entirety of circom2 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@phated/unionfs": "^4.5.0",
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
-    "circom2": "^0.2.0",
+    "circom2": "^0.2.1",
     "debug": "^4.3.3",
     "memfs": "^3.4.1",
     "shimmer": "^1.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,9 +286,9 @@ async function circom2({ circuit, debug }: { circuit: CircomCircuitConfig; debug
       if (fd == 2) {
         if (typeof data === "string") {
           stderr += data;
-          // This is a little fragile, but we assume the wasmer-js
-          // terminal character is a newline by itself
-          if (stderr.endsWith("\n")) {
+          // This is a little fragile, but we assume that circom2
+          // ends the failed compile with "previous errors were found"
+          if (stderr.includes("previous errors were found")) {
             const msg = stderr.trim();
             stderr = "";
             logger.error(msg);
@@ -297,9 +297,9 @@ async function circom2({ circuit, debug }: { circuit: CircomCircuitConfig; debug
           return data.length;
         } else {
           stderr += new TextDecoder().decode(data);
-          // This is a little fragile, but we assume the wasmer-js
-          // terminal character is a newline by itself
-          if (stderr.endsWith("\n")) {
+          // This is a little fragile, but we assume that circom2
+          // ends the failed compile with "previous errors were found"
+          if (stderr.includes("previous errors were found")) {
             const msg = stderr.trim();
             stderr = "";
             logger.error(msg);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,10 +1063,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circom2@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/circom2/-/circom2-0.2.0.tgz#e4a254725d5b02fc084f556639e6fed72c443a40"
-  integrity sha512-ODA9cNWS3+JYZ5QmkX6OZolBj3i1Ra4Ga6FR5fNkUAmG0HdN4v4LIeFPBXQp156cF20rWEFCLoysAzZAJL5gLA==
+circom2@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/circom2/-/circom2-0.2.1.tgz#6d898e8cf2e6b44fdf74a1080038eb1d37a65d64"
+  integrity sha512-y2bKFO8ebMhDKcSgrhuai1c4u37U4vOoVzS0f+6jvUZCYV4qzI98P/rRs9Vd6x/C7IKWrHn8PYvImTY26WtIGw==
   dependencies:
     "@wasmer/wasi" "^0.12.0"
     is-typed-array "^1.1.8"


### PR DESCRIPTION
While working on converting some circuits, I got really annoyed that I couldn't see the syntax error messages while running hardhat-circom.

This fixes it but might be even more fragile than before.