### PR TITLE
feat: Download URL ptau file & store in cache directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "debug": "^4.3.3",
     "memfs": "^3.4.1",
     "shimmer": "^1.2.1",
-    "snarkjs": "^0.4.14"
+    "snarkjs": "^0.4.14",
+    "undici": "^5.4.0"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
   const ptauIsUrl = ptau.startsWith("http://") || ptau.startsWith("https://");
   let normalizedPtauPath: string;
   if (ptauIsUrl) {
-    const ptauFile = ptau.replace(/^(http:|https:)\/\//, "").replace(new RegExp(path.sep, "g"), "_");
+    const ptauFile = ptau.replace(/^(http:|https:)\/\//, "").replace(/\//g, "_");
     const artifactPath = path.join(config.paths.artifacts, "circom");
     normalizedPtauPath = path.join(artifactPath, ptauFile);
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,13 @@ import * as fs from "fs/promises";
 import * as nodefs from "fs";
 import { ufs } from "@phated/unionfs";
 import { Volume, createFsFromVolume } from "memfs";
-import { existsSync } from "fs";
+import { existsSync, createWriteStream } from "fs";
 import { extendConfig, extendEnvironment, task, subtask, types } from "hardhat/config";
 import { HardhatPluginError } from "hardhat/plugins";
 import camelcase from "camelcase";
 import shimmer from "shimmer";
 import type { HardhatConfig, HardhatRuntimeEnvironment, HardhatUserConfig } from "hardhat/types";
+import { stream } from "undici";
 
 import logger from "./logger";
 import snarkjs from "./snarkjs";
@@ -92,6 +93,7 @@ export interface CircomConfig {
   inputBasePath: string;
   outputBasePath: string;
   ptau: string;
+  ptauDownload: string | undefined;
   circuits: CircomCircuitConfig[];
 }
 
@@ -134,12 +136,21 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
   const normalizedInputBasePath = normalize(root, inputBasePath) ?? defaultInputBasePath;
   const normalizedOutputBasePath = normalize(root, outputBasePath) ?? defaultOutputBasePath;
 
-  const normalizedPtauPath = path.resolve(normalizedInputBasePath, ptau);
+  const ptauIsUrl = ptau.startsWith("http://") || ptau.startsWith("https://");
+  let normalizedPtauPath: string;
+  if (ptauIsUrl) {
+    const ptauFile = ptau.replace(/^(http:|https:)\/\//, "").replace(new RegExp(path.sep, "g"), "_");
+    const artifactPath = path.join(config.paths.artifacts, "circom");
+    normalizedPtauPath = path.join(artifactPath, ptauFile);
+  } else {
+    normalizedPtauPath = path.resolve(normalizedInputBasePath, ptau);
+  }
 
   config.circom = {
     inputBasePath: normalizedInputBasePath,
     outputBasePath: normalizedOutputBasePath,
     ptau: normalizedPtauPath,
+    ptauDownload: ptauIsUrl ? ptau : undefined,
     circuits: [],
   };
 
@@ -544,11 +555,22 @@ async function circomCompile(
   { deterministic, debug, circuit: onlyCircuitNamed }: { deterministic: boolean; debug: boolean; circuit?: string },
   hre: HardhatRuntimeEnvironment
 ) {
-  const debugPath = path.join(hre.config.paths.artifacts, "circom");
-  if (debug) {
-    await fs.mkdir(path.join(debugPath), { recursive: true });
+  const artifactPath = path.join(hre.config.paths.artifacts, "circom");
+  const { ptauDownload } = hre.config.circom;
+  if (debug || ptauDownload) {
+    await fs.mkdir(path.join(artifactPath), { recursive: true });
   }
 
+  if (ptauDownload) {
+    if (existsSync(hre.config.circom.ptau)) {
+      logger.info(`Using cached Powers of Tau file at ${hre.config.circom.ptau}`);
+    } else {
+      logger.info(`Downloading Powers of Tau file from ${ptauDownload}`);
+      await stream(ptauDownload, { method: "GET", opaque: { path: hre.config.circom.ptau } }, ({ opaque }) =>
+        createWriteStream((opaque as { path: string }).path)
+      );
+    }
+  }
   const ptau = await fs.readFile(hre.config.circom.ptau);
 
   const zkeys: ZkeyFastFile[] = [];
@@ -564,7 +586,7 @@ async function circomCompile(
     try {
       compilerOutput = await compiler({
         circuit,
-        debug: debug ? { path: debugPath } : undefined,
+        debug: debug ? { path: artifactPath } : undefined,
       });
     } catch (err) {
       throw new HardhatPluginError(PLUGIN_NAME, `Unable to compile circuit named: ${circuit.name}`, err as Error);
@@ -578,7 +600,7 @@ async function circomCompile(
 
     const zkey = await snarker({
       circuit,
-      debug: debug ? { path: debugPath } : undefined,
+      debug: debug ? { path: artifactPath } : undefined,
       wasm,
       r1cs,
       ptau,

--- a/test/fixture-projects/hardhat-overrides/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-overrides/hardhat.config.ts
@@ -13,7 +13,7 @@ const config: HardhatUserConfig = {
   circom: {
     inputBasePath: "/circuits",
     outputBasePath: "/client/public",
-    ptau: "pot15_final.ptau",
+    ptau: "https://hermezptau.blob.core.windows.net/ptau/powersOfTau28_hez_final_15.ptau",
     circuits: [
       {
         name: "biomebase",

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -126,9 +126,12 @@ describe("Hardhat Circom", function () {
       assertPathEqualsAbsolute(third.input, "/circuits/input.json");
     });
 
-    it("Applies override inputBasePath and with required ptau name", function () {
+    it("Downloads URL ptau and outputs into artifacts cache", function () {
       const { ptau } = this.hre.config.circom;
-      assertPathEqualsAbsolute(ptau, "/circuits/pot15_final.ptau");
+      assertPathEqualsAbsolute(
+        ptau,
+        "/artifacts/circom/hermezptau.blob.core.windows.net_ptau_powersOfTau28_hez_final_15.ptau"
+      );
     });
 
     it("Should override outputBasePath and wasm name", function () {

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -128,7 +128,7 @@ describe("Hardhat Circom", function () {
 
     it("Downloads URL ptau and outputs into artifacts cache", function () {
       const { ptau } = this.hre.config.circom;
-      assertPathEqualsAbsolute(
+      assertPathIncludes(
         ptau,
         "/artifacts/circom/hermezptau.blob.core.windows.net_ptau_powersOfTau28_hez_final_15.ptau"
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,6 +3604,11 @@ undici@^4.14.1:
   resolved "https://registry.yarnpkg.com/undici/-/undici-4.15.1.tgz#c2c0e75f232178f0e6781f6b46c81ccc15065f6e"
   integrity sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==
 
+undici@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.4.0.tgz#c474fae02743d4788b96118d46008a24195024d2"
+  integrity sha512-A1SRXysDg7J+mVP46jF+9cKANw0kptqSFZ8tGyL+HBiv0K1spjxPX8Z4EGu+Eu6pjClJUBdnUPlxrOafR668/g==
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"


### PR DESCRIPTION
Closes #54 

If the `ptau` config item starts with `http://` or `https://`, the plugin will now download it and cache it in the artifacts directory. This will allow users to avoid checking a ptau file into their repository.

I first noticed this pattern with zkey-manager as used in cabal and I think it's generally how users want to work.