### PR TITLE
fix: Add exportSolidityCallData to groth16 & plonk snarkjs bindings

### DIFF
--- a/src/snarkjs.ts
+++ b/src/snarkjs.ts
@@ -31,6 +31,12 @@ const wrappedSnark = {
     ): Promise<boolean> {
       return snarkjs.groth16.verify(vk_verifier, publicSignals, proof, logger);
     },
+    exportSolidityCallData: async function groth16ExportSolidityCallData(
+      proof: unknown,
+      publicInputs: unknown
+    ): Promise<string> {
+      return snarkjs.groth16.exportSolidityCallData(proof, publicInputs);
+    },
   },
   plonk: {
     fullProve: async function plonkFullProve(
@@ -63,6 +69,12 @@ const wrappedSnark = {
       logger = pluginLogger
     ): Promise<boolean> {
       return snarkjs.plonk.verify(vk_verifier, publicSignals, proof, logger);
+    },
+    exportSolidityCallData: async function plonkExportSolidityCallData(
+      proof: unknown,
+      publicInputs: unknown
+    ): Promise<string> {
+      return snarkjs.plonk.exportSolidityCallData(proof, publicInputs);
     },
   },
   powersOfTau: {


### PR DESCRIPTION
Closes #53

I checked the output of these in circom-starter and they look correct. I'm also thinking it'd be cool to have some of these functions available to CircuitTestUtils so you don't need to figure out filesystem paths for them.