### PR TITLE
fix: Access ptau with filename to support sizes >2gb

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -486,7 +486,7 @@ async function groth16({
   debug?: { path: string };
   wasm: Required<MemFastFile>;
   r1cs: Required<MemFastFile>;
-  ptau: Buffer;
+  ptau: string;
 }): Promise<ZkeyFastFile> {
   const input = await getInputJson(circuit.input);
 
@@ -573,7 +573,7 @@ async function plonk({
   debug?: { path: string };
   wasm: Required<MemFastFile>;
   r1cs: Required<MemFastFile>;
-  ptau: Buffer;
+  ptau: string;
 }): Promise<ZkeyFastFile> {
   const input = await getInputJson(circuit.input);
 
@@ -654,7 +654,6 @@ async function circomCompile(
       );
     }
   }
-  const ptau = await fs.readFile(hre.config.circom.ptau);
 
   const zkeys: ZkeyFastFile[] = [];
   for (const circuit of hre.config.circom.circuits) {
@@ -686,7 +685,7 @@ async function circomCompile(
       debug: debug ? { path: artifactPath } : undefined,
       wasm,
       r1cs,
-      ptau,
+      ptau: hre.config.circom.ptau,
       // Only used by groth16
       deterministic,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -655,6 +655,10 @@ async function circomCompile(
     }
   }
 
+  if (!existsSync(hre.config.circom.ptau)) {
+    throw new HardhatPluginError(PLUGIN_NAME, `Could not locate ptau file: ${hre.config.circom.ptau}`);
+  }
+
   const zkeys: ZkeyFastFile[] = [];
   for (const circuit of hre.config.circom.circuits) {
     if (onlyCircuitNamed && onlyCircuitNamed !== circuit.name) {


### PR DESCRIPTION
Node's fs library doesn't support reading files larger than 2gb (because that is the limit on buffers). When the filename of a ptau is passed as a string, snarkjs will create a "paged" fastfile underneath. This change switches to using the ptau filename string instead of reading as a buffer to solve this issue. We only use the ptau reference once, so we don't need to worry about it being in memory for longer.

The only downside I can see about this is that we won't error as early if the ptau file doesn't exist. But now that I'm thinking about it, I can add an `existsSync` call where we used to read the file into a buffer.