### PR TITLE
Update to circom v2.1.6 via circom2 v0.2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bl": "^6.0.0",
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
-    "circom2": "^0.2.10",
+    "circom2": "^0.2.16",
     "circom_runtime": "0.1.21",
     "debug": "^4.3.4",
     "ffjavascript": "0.2.56",


### PR DESCRIPTION
circom v2.1.0 doesn't correctly parse negative numbers as input data (https://github.com/iden3/circom/issues/208). This updates circom to v2.1.6 via the circom2 package https://www.npmjs.com/package/circom2 v0.2.16.