### PR TITLE
Update to circom_runtime to parse negative input values correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bl": "^6.0.0",
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
-    "circom2": "^0.2.10",
+    "circom2": "^0.2.16",
     "circom_runtime": "0.1.21",
     "debug": "^4.3.4",
     "ffjavascript": "0.2.56",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
     "circom2": "0.2.12",
-    "circom_runtime": "0.1.21",
+    "circom_runtime": "git+ssh://git@github.com/okwme/circom_runtime.git",
     "debug": "^4.3.4",
     "ffjavascript": "0.2.56",
     "memfs": "^3.4.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bl": "^6.0.0",
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
-    "circom2": "0.2.12",
+    "circom2": "0.2.16",
     "circom_runtime": "git+ssh://git@github.com/okwme/circom_runtime.git",
     "debug": "^4.3.4",
     "ffjavascript": "0.2.56",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bl": "^6.0.0",
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
-    "circom2": "^0.2.12",
+    "circom2": "0.2.12",
     "circom_runtime": "0.1.21",
     "debug": "^4.3.4",
     "ffjavascript": "0.2.56",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bl": "^6.0.0",
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
-    "circom2": "^0.2.16",
+    "circom2": "^0.2.12",
     "circom_runtime": "0.1.21",
     "debug": "^4.3.4",
     "ffjavascript": "0.2.56",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "camelcase": "^6.3.0",
     "circom": "0.5.46",
     "circom2": "0.2.16",
-    "circom_runtime": "git+ssh://git@github.com/okwme/circom_runtime.git",
+    "circom_runtime": "git+ssh://git@github.com/okwme/circom_runtime.git#f9bdd820708ea0c9a67c36d754217e7c26fd37ab",
     "debug": "^4.3.4",
     "ffjavascript": "0.2.56",
     "memfs": "^3.4.8",


### PR DESCRIPTION
closing #80 in favor of this. It was circom_runtime that was causing the problems. I've made a patched / forked version and it's correctly parsing negative input values now. My fork can be replaced if this is merged: https://github.com/iden3/circom_runtime/pull/87