### PR TITLE
Read include from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ module.exports = {
     inputBasePath: "./mycircuits/",
     // (optional) Base path for files being output, defaults to `./circuits/`
     outputBasePath: "./client/",
+    // (optional) Include paths for circuits using libraries (adds `-l` flags to the circom call)
+    include: ["/path/to/include"],
     // (required) The final ptau file, relative to inputBasePath, from a Phase 1 ceremony
     ptau: "pot15_final.ptau",
     // (required) Each object in this array refers to a separate circuit


### PR DESCRIPTION
Closes #83

Adds the option to set `include` in the hardhat config, so that the CLI tool knows that it needs to call `circom` with the corresponding `-l` flags.

This is useful for projects that use libraries.

> [!NOTE]
> Maybe I'm missing something, but I couldn't find this functionality in `hardhat-circom`!